### PR TITLE
Fixed Cross-site Scripting (XSS) Vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,9 @@
     "time-grunt": "^1.4.0",
     "webpack": "^4.6.0",
     "webpack-dev-server": "^3.1.3"
+  },
+  "dependencies": {
+    "dompurify": "^2.0.8",
+    "jsdom": "^16.2.0"
   }
 }

--- a/src/lib/defaultCommands.js
+++ b/src/lib/defaultCommands.js
@@ -3,6 +3,11 @@ import * as utils from './utils.js';
 import { ie as IE_VER } from './browser.js';
 import _tmpl from './templates.js';
 
+const createDOMPurify = require('dompurify');
+const { JSDOM } = require('jsdom');
+const window = new JSDOM('').window;
+const DOMPurify = createDOMPurify(window);
+
 // In IE < 11 a BR at the end of a block level element
 // causes a line break. In all other browsers it's collapsed.
 var IE_BR_FIX = IE_VER && IE_VER < 11;
@@ -420,7 +425,7 @@ var defaultCmds = {
 
 					html += '</table>';
 
-					editor.wysiwygEditorInsertHtml(html);
+					editor.wysiwygEditorInsertHtml(DOMPurify.sanitize(html));
 					editor.closeDropDown(true);
 					e.preventDefault();
 				}
@@ -502,7 +507,7 @@ var defaultCmds = {
 					}
 
 					editor.wysiwygEditorInsertHtml(
-						'<img' + attrs + ' src="' + url + '" />'
+						'<img' + DOMPurify.sanitize(attrs) + ' src="' + DOMPurify.sanitize(url) + '" />'
 					);
 				}
 			);
@@ -547,8 +552,8 @@ var defaultCmds = {
 
 					if (!editor.getRangeHelper().selectedHtml() || text) {
 						editor.wysiwygEditorInsertHtml(
-							'<a href="' + 'mailto:' + email + '">' +
-								(text || email) +
+							'<a href="' + 'mailto:' + DOMPurify.sanitize(email) + '">' +
+								(DOMPurify.sanitize(text) || DOMPurify.sanitize(email)) +
 							'</a>'
 						);
 					} else {
@@ -607,7 +612,7 @@ var defaultCmds = {
 					text = text || url;
 
 					editor.wysiwygEditorInsertHtml(
-						'<a href="' + url + '">' + text + '</a>'
+						'<a href="' + DOMPurify.sanitize(url) + '">' + DOMPurify.sanitize(text) + '</a>'
 					);
 				} else {
 					editor.execCommand('createlink', url);


### PR DESCRIPTION
:gear:  **Fix:**

As `editor.wysiwygEditorInsertHtml()` is defined to accept HTML input, we need to allow HTML input but prevent JavaScript code to execute/XSS attacks. So, I used **[DOMPurify](https://github.com/cure53/DOMPurify)** to accept HTML but no JavaScript thus fixing the XSS vulnerability.

:question:  **How Does DOMPurify Work?**

DOMPurify sanitizes HTML and prevents XSS attacks. You can feed DOMPurify with string full of dirty HTML and it will return a string (unless configured otherwise) with clean HTML. DOMPurify will strip out everything that contains dangerous HTML and thereby prevent XSS attacks and other nastiness. It's also damn bloody fast. We use the technologies the browser provides and turn them into an XSS filter. The faster your browser, the faster DOMPurify will be. [Source: _[DOMPurify GitHub Repository](https://github.com/cure53/DOMPurify)_)

:question: **How:**

DOMPurify sanitizes HTML and prevents XSS attacks. You can feed DOMPurify with string full of dirty HTML and it will return a string (unless configured otherwise) with clean HTML. DOMPurify will strip out everything that contains dangerous HTML and thereby prevent XSS attacks and other nastiness. It's also damn bloody fast. We use the technologies the browser provides and turn them into an XSS filter. The faster your browser, the faster DOMPurify will be.

The `editor.wysiwygEditorInsertHtml()` function doesn't properly sanitize HTML input thus resulting in an XSS when given malicious JavaScript code to inputs: `email`, `text`, `url`,`html`. So excluding JavaScript events and functions but accepting only the HTML code can mitigate this vulnerability.

This fix has covered every possible occurrence of an XSS vulnerability via the `editor.wysiwygEditorInsertHtml()` function, a good reference is from the one who found this vulnerability (Edric Teo) itself: https://edricteo.com/sceditor-xss-vulnerability-in-version-2.1.3/.

:fire: **Fix On Action:**

    $ npm install -g grunt-cli
    $ npm install
    $ grunt build
    $ grunt test
    $ grunt release
    $ npm run dev

<hr>

### :v: **Fixed!**

<hr>